### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### 集成使用的时候可以有两种姿势：
 
-1. 使用Cocoapods的同学可以：pod 'VisualEditWidgets', '~> 0.3.3' 
+1. 使用CocoaPods的同学可以：pod 'VisualEditWidgets', '~> 0.3.3' 
 2. 喜欢自己管理源码的同学可以直接下载源代码，讲 VEWidgets 目录加入项目就行。
 
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
